### PR TITLE
Voyage Calculation improvements:

### DIFF
--- a/native/ThreadPool.h
+++ b/native/ThreadPool.h
@@ -30,7 +30,7 @@ private:
 	size_t maxThreads;
 	std::mutex lock;
 	using lockScope = std::lock_guard<std::mutex>;
-    std::list<std::thread> threads;
+    std::list<std::shared_ptr<std::thread>> threads;
 	std::vector<task> tasks;
 };
 

--- a/native/VoyageCalculator.cpp
+++ b/native/VoyageCalculator.cpp
@@ -116,8 +116,8 @@ VoyageCalculator::VoyageCalculator(const char* jsonInput) noexcept :
 		if (!config_includeFrozenCrew && crew["frozen"] != 0)
 			continue;
 
-		/*if (!config_includeAwayCrew && crew["active_id"] != 0)
-			continue;*/
+		if (!config_includeAwayCrew && crew["active_id"] != 0)
+			continue;
 
 		Crew c;
 		c.id = crew["id"];

--- a/native/VoyageCalculator.h
+++ b/native/VoyageCalculator.h
@@ -68,6 +68,7 @@ struct Crew
 	// treated as a bool, but avoiding bit masking vector<bool> specialization for multithreading
 	mutable std::vector<int> considered;
 	const Crew *original{nullptr};
+	std::array<const Crew*, SLOT_COUNT> slotCrew;
 	unsigned int score{0};
 };
 
@@ -105,6 +106,7 @@ public:
 
 private:
 	void calculate() noexcept;
+	void refine() noexcept;
 	void fillSlot(size_t slot, unsigned int minScore, size_t minDepth, size_t seedSlot, size_t thread = -1) noexcept;
 	float calculateDuration(const std::array<const Crew *, SLOT_COUNT> &complement, bool debug = false) noexcept;
 	unsigned int computeScore(const Crew& crew, size_t skill, size_t trait) const noexcept;

--- a/native/VoyageCalculator.h
+++ b/native/VoyageCalculator.h
@@ -72,18 +72,6 @@ struct Crew
 	unsigned int score{0};
 };
 
-struct SortedCrew
-{
-	std::array<std::vector<Crew>, SLOT_COUNT> slotRosters;
-
-	void setSearchDepth(size_t depth) noexcept
-	{
-		this->depth = depth;
-	}
-
-	size_t depth = 0;
-};
-
 class VoyageCalculator
 {
 public:
@@ -106,9 +94,14 @@ public:
 
 private:
 	void calculate() noexcept;
-	void refine() noexcept;
+	void findBest() noexcept;
 	void fillSlot(size_t slot, unsigned int minScore, size_t minDepth, size_t seedSlot, size_t thread = -1) noexcept;
+	void updateSlotRosterScores() noexcept;
+	void resetRosters() noexcept;
 	float calculateDuration(const std::array<const Crew *, SLOT_COUNT> &complement, bool debug = false) noexcept;
+	
+	// old disused functions
+	void refine() noexcept;
 	unsigned int computeScore(const Crew& crew, size_t skill, size_t trait) const noexcept;
 
 	nlohmann::json j;
@@ -124,13 +117,14 @@ private:
 	std::string secondarySkillName;
 	const int shipAntiMatter;
 	std::vector<Crew> roster;
-	SortedCrew sortedRoster;
+	std::array<std::vector<Crew>, SLOT_COUNT> slotRosters;
 
 	std::vector<std::array<const Crew *, SLOT_COUNT>> considered; // fillSlot recursion working copy
 
 	ThreadPool threadPool;
 	std::mutex calcMutex;
 
+	const size_t config_searchDepth{6};
 	const float config_skillPrimaryMultiplier{3.5};
 	const float config_skillSecondaryMultiplier{2.5};
 	const float config_skillMatchingMultiplier{1.0};
@@ -138,12 +132,14 @@ private:
 	const bool config_includeAwayCrew{false};
 	const bool config_includeFrozenCrew{false};
 
-	std::array<const std::vector<Crew> *, SLOT_COUNT> slotRoster;
+	std::array<std::vector<const Crew*>, SLOT_COUNT> sortedSlotRosters;
 
 	std::array<const Crew *, SLOT_COUNT> bestconsidered;
 	float bestscore{0.0};
 
-	Timer timer{"voyage calculation"};
+	Timer totalTime{"voyage calculation"};
+	Timer voyageCalcTime{"actual calc", false};
+	Timer scoreUpdateTime{"score update", false};
 };
 
 } //namespace VoyageTools


### PR DESCRIPTION
This is in reaction to @paulbert's PR #12 .

I reconsidered my earlier, previously unimplemented idea of iterative swapping, but now I remembered why it wouldn't be optimal. There can be (and even in my sporadic testing I encountered some) situations where a swap does not directly result in a better score, unless the swap is recursive - but there is no way to know for certain when to stop recursively swapping without essentially resorting to brute force.

This PR is a compromise - it adds on a refinement step that performs iterative swapping after the brute force portion.

A further improvement is yet possible by using this refinement step to instead extend the filtered roster and perform the brute force again. This combination could be placed into a loop for further gains. I will probably work on this next time.