### PR TITLE
Added voyage crew ranking calculation.

### DIFF
--- a/native/NativeExtension.cpp
+++ b/native/NativeExtension.cpp
@@ -1,5 +1,6 @@
 #include "NativeExtension.h"
 #include "VoyageCalculator.h"
+#include "VoyageCrewRanker.h"
 
 using v8::FunctionTemplate;
 
@@ -21,6 +22,89 @@ public:
 		}, finalScore);
 
 		result = ResultToString(finalResult, finalScore);
+	}
+
+	void HandleOKCallback() override
+	{
+		Nan::HandleScope scope;
+		v8::Local<v8::Value> argv[] = { Nan::New(result.c_str(), result.size()).ToLocalChecked() };
+		callback->Call(1, argv);
+	};
+
+	void HandleProgressCallback(const char *data, size_t size) override
+	{
+		Nan::HandleScope scope;
+		v8::Local<v8::Value> argv[] = { Nan::New(data, size).ToLocalChecked() };
+		progressCallback->Call(1, argv);
+	}
+
+private:
+	std::string ResultToString(const std::array<const VoyageTools::Crew*, VoyageTools::SLOT_COUNT>& res, double score) noexcept
+	{
+		nlohmann::json j;
+		for (int i = 0; i < VoyageTools::SLOT_COUNT; i++)
+		{
+			j["selection"][voyageCalculator->GetSlotName(i)] = res[i]->id;
+		}
+		j["score"] = score;
+		return j.dump();
+	}
+
+	Nan::Callback *progressCallback;
+	std::string result;
+	std::unique_ptr<VoyageTools::VoyageCalculator> voyageCalculator;
+};
+
+class VoyageCrewRankWorker : public Nan::AsyncProgressWorker
+{
+	std::string input;
+public:
+	VoyageCrewRankWorker(Nan::Callback *callback, Nan::Callback *progressCallback, const char *input)
+		: Nan::AsyncProgressWorker(callback)
+		, progressCallback(progressCallback)
+		, input(input)
+	{
+	}
+
+	void Execute(const Nan::AsyncProgressWorker::ExecutionProgress &progress) override
+	{
+		using namespace VoyageTools;
+		std::vector<RankedCrew> rankedCrew = RankVoyageCrew(input.c_str());
+
+		std::stringstream ss;
+		ss << "Score,";
+		for (unsigned int iAlt = 0; iAlt < RankedCrew::altLevels; ++iAlt) {
+			ss << "Alt " << iAlt+1 << ",";
+		}
+		ss << "Status,Crew,Voyages\n";
+
+		std::array<const char*,SKILL_COUNT> skillNames = {"CMD", "SCI", "SEC", "ENG", "DIP", "MED"};
+		std::array<const char*,SKILL_COUNT> altSkillNames = {"cmd", "sci", "sec", "eng", "dip", "med"};
+
+		for (const RankedCrew &crew : rankedCrew) {
+			ss << crew.score << ",";
+			for (unsigned int iAlt = 0; iAlt < RankedCrew::altLevels; ++iAlt) {
+				ss << (crew.altScores.empty()?0:crew.altScores[iAlt]) << ",";
+			}
+			std::string status;
+			if (crew.crew.frozen) {
+				status = "F";
+			} else if (crew.crew.ff100) {
+				status = "I?";
+			} else {
+				status = '0'+crew.crew.max_rarity;
+			}
+			ss << status << "," << crew.crew.name << ",";
+			for (auto skills : crew.voySkills) {
+				ss << skillNames[skills.first] << "/" << skillNames[skills.second] << " ";
+			}
+			for (auto altSkills : crew.altVoySkills) {
+				ss << altSkillNames[altSkills.first] << "/" << altSkillNames[altSkills.second] << " ";
+			}
+			ss << "\n";
+		}
+
+		result = ss.str();
 	}
 
 	void HandleOKCallback() override
@@ -91,10 +175,50 @@ NAN_METHOD(calculateVoyageRecommendations)
 	//return undefined
 }
 
+NAN_METHOD(calculateVoyageCrewRank)
+{
+	//std::cout << std::thread::hardware_concurrency() << " concurrent threads are supported.\n";
+
+	if (info.Length() != 3)
+	{
+		Nan::ThrowTypeError("Wrong number of arguments; 3 expected");
+		return;
+	}
+
+	if (!info[0]->IsString())
+	{
+		Nan::ThrowTypeError("Wrong argument (string expected)");
+		return;
+	}
+
+	if (!info[1]->IsFunction())
+	{
+		Nan::ThrowTypeError("Wrong argument (callback expected)");
+		return;
+	}
+
+	if (!info[2]->IsFunction())
+	{
+		Nan::ThrowTypeError("Wrong argument (callback expected)");
+		return;
+	}
+
+	v8::Local<v8::Function> callbackHandle = info[1].As<v8::Function>();
+	v8::Local<v8::Function> progressCallbackHandle = info[2].As<v8::Function>();
+
+	Nan::AsyncQueueWorker(new VoyageCrewRankWorker(new Nan::Callback(callbackHandle), new Nan::Callback(progressCallbackHandle),
+		*v8::String::Utf8Value(info[0]->ToString())));
+
+	//return undefined
+}
+
 NAN_MODULE_INIT(InitAll)
 {
 	Nan::Set(target, Nan::New("calculateVoyageRecommendations").ToLocalChecked(),
-		Nan::GetFunction(Nan::New<FunctionTemplate>(calculateVoyageRecommendations)).ToLocalChecked());
+	Nan::GetFunction(Nan::New<FunctionTemplate>(calculateVoyageRecommendations)).ToLocalChecked());
+
+	Nan::Set(target, Nan::New("calculateVoyageCrewRank").ToLocalChecked(),
+	Nan::GetFunction(Nan::New<FunctionTemplate>(calculateVoyageCrewRank)).ToLocalChecked());
 }
 
 NODE_MODULE(NativeExtension, InitAll)

--- a/native/NativeExtension.h
+++ b/native/NativeExtension.h
@@ -4,5 +4,6 @@
 #include <nan.h>
 
 NAN_METHOD(calculateVoyageRecommendations);
+NAN_METHOD(calculateVoyageCrewRank);
 
 #endif

--- a/native/VoyageCalculator.h
+++ b/native/VoyageCalculator.h
@@ -70,20 +70,34 @@ struct Crew
 	const Crew *original{nullptr};
 	std::array<const Crew*, SLOT_COUNT> slotCrew;
 	unsigned int score{0};
+	unsigned int max_rarity{0};
+	bool frozen;
+	bool ff100 = false;
 };
+using CrewArray = std::array<const Crew *, SLOT_COUNT>;
 
 class VoyageCalculator
 {
 public:
-	VoyageCalculator(const char* jsonInput) noexcept;
+	VoyageCalculator(const char* jsonInput, bool rankMode = false) noexcept;
+
+	void SetInput(size_t primarySkill, size_t secondarySkill) noexcept
+	{
+		this->primarySkill = primarySkill;
+		this->secondarySkill = secondarySkill;
+	}
+	void DisableTraits()
+	{
+		std::fill(slotTraits.begin(), slotTraits.end(), (size_t)-1);
+	}
 
 	const std::string& GetSlotName(size_t index) const noexcept
 	{
 		return slotNames[index];
 	}
 
-	std::array<const Crew *, SLOT_COUNT> Calculate(
-		std::function<void(const std::array<const Crew *, SLOT_COUNT>&, double)> progressCallback,
+	CrewArray Calculate(
+		std::function<void(const CrewArray&, double)> progressCallback,
 		double& score) noexcept
 	{
 		progressUpdate = progressCallback;
@@ -91,6 +105,10 @@ public:
 		score = bestscore;
 		return bestconsidered;
 	}
+
+	CrewArray GetAlternateCrew(unsigned int level) const noexcept;
+
+	const std::vector<Crew>& GetRoster() const noexcept { return roster; }
 
 private:
 	void calculate() noexcept;
@@ -105,6 +123,8 @@ private:
 	unsigned int computeScore(const Crew& crew, size_t skill, size_t trait) const noexcept;
 
 	nlohmann::json j;
+
+	bool rankMode; // in rank calculation mode, traits are ignored
 
 	std::function<void(const std::array<const Crew *, SLOT_COUNT>&, double)> progressUpdate;
 	std::array<std::string, SLOT_COUNT> slotNames;

--- a/native/VoyageCrewRanker.cpp
+++ b/native/VoyageCrewRanker.cpp
@@ -1,0 +1,89 @@
+#include "VoyageCrewRanker.h"
+#include <unordered_map>
+
+namespace VoyageTools
+{
+
+std::vector<RankedCrew> RankVoyageCrew(const char *jsonInput) noexcept
+{
+	std::unordered_map<int, RankedCrew> rankedCrew;
+
+	// compute for all voyage skill combos
+	for (size_t primarySkill = 0; primarySkill < SKILL_COUNT; ++primarySkill)
+	for (size_t secondarySkill = 0; secondarySkill < SKILL_COUNT; ++secondarySkill)
+	{
+		if (primarySkill == secondarySkill)
+			continue;
+
+		VoyageCalculator calculator(jsonInput, true);
+		calculator.SetInput(primarySkill, secondarySkill);
+		calculator.DisableTraits();
+
+		double dontcare;
+		std::array<const Crew*, SLOT_COUNT> voyCrew = 
+			calculator.Calculate([](auto...){}, dontcare);
+
+		for (const Crew * crew : voyCrew) {
+			RankedCrew &rCrew = rankedCrew[crew->id];
+			rCrew.crew = *crew;
+			++rCrew.score;
+			rCrew.voySkills.push_back(std::make_pair(primarySkill, secondarySkill));
+		}
+
+		for (unsigned int altLevel = 0; altLevel < RankedCrew::altLevels; ++altLevel) {
+			CrewArray altCrew = calculator.GetAlternateCrew(altLevel);
+			for (const Crew * crew : altCrew) {
+				if (crew == nullptr)
+					continue;
+				RankedCrew &rCrew = rankedCrew[crew->id];
+				rCrew.crew = *crew;
+				rCrew.altScores.resize(RankedCrew::altLevels);
+				++rCrew.altScores[altLevel];
+				
+				bool hasAltSkills = false;
+				for (auto skillPair : rCrew.altVoySkills) {
+					if (skillPair.first == primarySkill && skillPair.second == secondarySkill) {
+						hasAltSkills = true;
+						break;
+					}
+				}
+				if (!hasAltSkills) {
+					rCrew.altVoySkills.push_back(std::make_pair(primarySkill, secondarySkill));
+				}
+			}
+		}
+	}
+
+	// add in immortalized crew
+	VoyageCalculator calculator(jsonInput);
+	for (const Crew &crew : calculator.GetRoster()) {
+		if (crew.ff100 && !crew.frozen) {
+			RankedCrew &rCrew = rankedCrew[crew.id];
+			rCrew.crew = crew;
+		}
+	}
+
+	std::vector<RankedCrew> sortedCrew;
+	for (auto rankedPair : rankedCrew) {
+		sortedCrew.push_back(rankedPair.second);
+	}
+	std::sort(sortedCrew.begin(), sortedCrew.end(), [](const auto &left, const auto &right) {
+		if (left.score != right.score)
+			return left.score > right.score;
+		if (left.altScores.size() != right.altScores.size())
+			return left.altScores.size() > right.altScores.size();
+		if (left.altScores.size()) {
+			for (size_t iAlt = 0; iAlt < RankedCrew::altLevels; ++iAlt) {
+				if (left.altScores[iAlt] != right.altScores[iAlt])
+					return left.altScores[iAlt] > right.altScores[iAlt];
+			}
+		}
+		if (left.crew.max_rarity != right.crew.max_rarity)
+			return left.crew.max_rarity > right.crew.max_rarity;
+		return left.crew.name < right.crew.name;
+	});
+
+	return sortedCrew;
+}
+
+} // namespace VoyageTools

--- a/native/VoyageCrewRanker.h
+++ b/native/VoyageCrewRanker.h
@@ -1,0 +1,29 @@
+#ifndef VOYAGE_CREW_RANKER_H
+#define VOYAGE_CREW_RANKER_H
+#include <array>
+#include <vector>
+#include <algorithm>
+#include <functional>
+#include <chrono>
+#include <set>
+#include <iostream>
+
+#include "VoyageCalculator.h"
+
+namespace VoyageTools
+{
+
+struct RankedCrew {
+	Crew crew;
+	unsigned int score = 0;
+	static constexpr unsigned int altLevels = 5; // TODO: make this configurable
+	std::vector<unsigned int> altScores;
+	std::vector<std::pair<size_t,size_t>> voySkills;
+	std::vector<std::pair<size_t,size_t>> altVoySkills;
+};
+
+std::vector<RankedCrew> RankVoyageCrew(const char *jsonInput) noexcept;
+
+} //namespace VoyageTools
+
+#endif

--- a/native/test/index.js
+++ b/native/test/index.js
@@ -9,5 +9,10 @@ describe('native extension', function() {
       console.log(testString);
     }), 'undefined');
     //assert.equal(typeof nativeExtension.calculateVoyageRecommendations(), 'string');
+    assert.equal(typeof nativeExtension.calculateVoyageCrewRank('{}', function(testString) {
+      console.log(testString);
+    }, function(testString) {
+      console.log(testString);
+    }), 'undefined');
   });
 });


### PR DESCRIPTION
There's an exception that doesn't appear to cause any real problems but should probably be fixed:

CrewRecommendations.js:437 Uncaught (in promise) ReferenceError: shell is not defined
    at Promise.then.e (CrewRecommendations.js:437)
    at <anonymous>

Not sure how to fix it and out of time for now.

The UX for this is very rough. Simply added a button and the result is a CSV file.

General idea is to rank your crew in order of voyage usefulness in order to help you determine which crew to freeze.

The sheet also includes unfrozen FF level 100 crew at the end, in order by rarity, then name.

The calculation uses all inputs as usual but traits are completely ignored. It simulates every possible skill combo (30 total) and additionally gives points for the next 5th (should be configurable) crew in each slot based on the heuristic voyage strength score.

Fields are:
Score - number of voyages where the crew was slotted
Alt # - number of times crew was chosen as a #nth alternate (based on scoring heuristic, not actual simulations)
Status - F for frozen, I? for FF level 100 unfrozen, otherwise # for rarity star count
Crew - crew name
Voyages - listing of voyage skill combos. Uppercase combos are where the crew was actually slotted and lowercase combos are for alternate standings.