### PR TITLE
Changed Fleet chat so that recent messages will be properly displayed.

### DIFF
--- a/src/components/FleetDetails.js
+++ b/src/components/FleetDetails.js
@@ -270,7 +270,7 @@ export class FleetDetails extends React.Component {
 				data.pubnub.history(
 					{
 						channel: data.subscribedChannels.fleet,
-						reverse: true,
+						reverse: false,
 						count: 30 // how many items to fetch
 					},
 					(status, response) => {


### PR DESCRIPTION
I noticed after joining a somewhat more chatty fleet that the chat is actually pulling the oldest 30 messages (within whatever window pubnub is giving.)

Flipping the bit will cause the 30 most recent chats to be pulled instead. They will still display oldest-first based on my testing.