### PR TITLE
Voyage estimation via simulated annealing approach

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,6 +67,11 @@
         "condition_variable": "cpp",
         "ratio": "cpp",
         "set": "cpp",
-        "thread": "cpp"
+        "thread": "cpp",
+        "*.tcc": "cpp",
+        "cctype": "cpp",
+        "cwctype": "cpp",
+        "optional": "cpp",
+        "string_view": "cpp"
     }
 }

--- a/README.md
+++ b/README.md
@@ -98,13 +98,14 @@ You can inspect the active state of crew by clicking on the little "baloon" icon
 ### To get started:
 Clone the repo and build with `node.js` v 10.
 
-Minimal set of steps required (on a Windows machine)
+Minimal set of steps required
 * `git clone --recurse-submodules https://github.com/IAmPicard/StarTrekTimelinesSpreadsheet.git`
 * `cd StarTrekTimelinesSpreadsheet\STTApi`
 * `npm install`
 * `cd ..`
 * `npm install`
   * You may also need to `npm install electron` if you see the message `Error: Electron failed to install correctly, please delete node_modules/electron and try installing again`
+  * You may need to `npm install bindings nan` if you see errors using the voyage estimator tool
 * `node_modules\.bin\electron-rebuild.cmd`
   * `node_modules/.bin/electron-rebuild` on Ubuntu
 * `npm run dev`
@@ -113,6 +114,15 @@ Minimal set of steps required (on a Windows machine)
 
 ##### Development
 * Run `npm run dev` to start webpack-dev-server. Electron will launch automatically after compilation.
+
+If changes are made to the C++ native codebase under `/native`:
+* You can compile to see warnings/errors with the following (though it does not build for proper integration with the app)
+  * `$ rm -rf native/build/Release`
+  * `$ cd native/build`
+  * `$ make`
+To rebuild for use with the app run the `electron-rebuild` executable under `node_modules/.bin/`
+
+If you delete `node_modules/stt*` to get back to a cleaner state, `npm install` again to rebuild the C++ modules. If the install fails, revert any local changes to `package-lock.json`.
 
 ##### Production
 _You have two options, an automatic build or two manual steps_

--- a/native/NativeExtension.cpp
+++ b/native/NativeExtension.cpp
@@ -180,6 +180,9 @@ class VoyageCrewRankWorker : public Nan::AsyncProgressWorker
 	std::unique_ptr<VoyageTools::VoyageCalculator> voyageCalculator;
 };
 
+constexpr std::array<const char *, VoyageTools::SKILL_COUNT> VoyageCrewRankWorker::skillNames;
+constexpr std::array<const char *, VoyageTools::SKILL_COUNT> VoyageCrewRankWorker::altSkillNames;
+
 NAN_METHOD(calculateVoyageRecommendations)
 {
 	if (info.Length() != 3)

--- a/native/VoyageCalculator.cpp
+++ b/native/VoyageCalculator.cpp
@@ -412,6 +412,10 @@ void VoyageCalculator::calculateSA() noexcept
 			 << (sk == binaryConfig.secondarySkill ? "(sec)" : "")
 			 << std::endl;
 	}
+
+	bestconsidered = assignments;
+	bestscore = voyTime;
+	progressUpdate(bestconsidered, bestscore);
 }
 
 void VoyageCalculator::calculate() noexcept
@@ -422,24 +426,24 @@ void VoyageCalculator::calculate() noexcept
 		log << std::endl << "END NEW CALCULATION METHOD" << std::endl << std::endl;
 	}
 
-	for (unsigned int iteration = 1;;++iteration) {
-		log << "iteration " << iteration << std::endl;
+	// for (unsigned int iteration = 1;;++iteration) {
+	// 	log << "iteration " << iteration << std::endl;
 
-		float prevBest = bestscore;
+	// 	float prevBest = bestscore;
 
-		resetRosters();
-		updateSlotRosterScores();
-		findBest();
+	// 	resetRosters();
+	// 	updateSlotRosterScores();
+	// 	findBest();
 
-		if (bestscore > prevBest) {
-			continue;
-		} else {
-			log << "final result:" << std::endl;
-			calculateDuration(bestconsidered, true);
-			log << "stopping after " << iteration << " iterations" << std::endl;
-			break;
-		}
-	}
+	// 	if (bestscore > prevBest) {
+	// 		continue;
+	// 	} else {
+	// 		log << "final result:" << std::endl;
+	// 		calculateDuration(bestconsidered, true);
+	// 		log << "stopping after " << iteration << " iterations" << std::endl;
+	// 		break;
+	// 	}
+	// }
 }
 
 void VoyageCalculator::resetRosters() noexcept

--- a/native/VoyageCalculator.cpp
+++ b/native/VoyageCalculator.cpp
@@ -41,6 +41,8 @@ constexpr float ssChance = 0.25f;
 constexpr float osChance = 0.1f;
 constexpr unsigned int dilPerMin = 5;
 
+static constexpr std::array<const char *, SKILL_COUNT> SKILL_NAMES = {"COM", "SCI", "SEC", "ENG", "DIP", "MED"};
+
 unsigned int VoyageCalculator::computeScore(const Crew& crew, std::uint8_t skill, size_t traitSlot) const noexcept
 {
 	if (crew.skills[skill] == 0)
@@ -104,10 +106,26 @@ VoyageCalculator::VoyageCalculator(const char* jsonInput, bool rankMode) noexcep
 			c.skillMaxProfs[i] = skillData[i*3 + 2];
 			c.skillMinProfs[i] = skillData[i*3 + 1];
 			c.skills[i] = skillData[i*3] + (c.skillMaxProfs[i] + c.skillMinProfs[i]) / 2;
+			float skill = skillData[i*3] + (c.skillMaxProfs[i] + c.skillMinProfs[i]) / 2.0f;
+
+			if (skill > 0)
+			{
+				for (uint iSkill = 0; iSkill < SKILL_COUNT; ++iSkill)
+				{
+					if (iSkill == binaryConfig.primarySkill)
+						c.weightedSum += skill * binaryConfig.skillPrimaryMultiplier;
+					else if (iSkill == binaryConfig.secondarySkill)
+						c.weightedSum += skill * binaryConfig.skillSecondaryMultiplier;
+					else
+						c.weightedSum += skill * binaryConfig.skillMatchingMultiplier;
+				};
+			}
 		}
 
-		log << c.name << " " << c.skills[0] << " " << c.skills[1] << " " << c.skills[2] << " "
-			<< c.skills[3] << " " << c.skills[4] << " " << c.skills[5] << " " << std::endl;
+		log << c.name;
+		for (uint s = 0; s < SKILL_NAMES.size(); ++s)
+			log << " " << SKILL_NAMES[s] << ":" << c.skills[s];
+		log << " ws: " << c.weightedSum << std::endl;
 
 		roster.emplace_back(std::move(c));
 	}
@@ -510,9 +528,10 @@ float VoyageCalculator::calculateDuration(const std::array<const Crew *, SLOT_CO
 
 	if (debug)
 	{
-		log << shipAM << " "
-			<< totals.skills[0] << " " << totals.skills[1] << " " << totals.skills[2] << " "
-			<< totals.skills[3] << " " << totals.skills[4] << " " << totals.skills[5] << std::endl;
+		log << shipAM;
+		for (uint s = 0; s < SKILL_NAMES.size(); ++s)
+			log << " " << SKILL_NAMES[s] << ":" << totals.skills[s];
+		log << std::endl;
 	}
 
 	unsigned int PrimarySkill = totals.skills[binaryConfig.primarySkill];

--- a/native/VoyageCalculator.h
+++ b/native/VoyageCalculator.h
@@ -79,6 +79,7 @@ struct Crew
 	unsigned int score{0};
 	unsigned int max_rarity{0};
 	bool ff100 = false;
+	float weightedSum{0};
 };
 using CrewArray = std::array<const Crew *, SLOT_COUNT>;
 

--- a/native/VoyageCalculator.h
+++ b/native/VoyageCalculator.h
@@ -120,7 +120,7 @@ private:
 	void updateSlotRosterScores() noexcept;
 	void resetRosters() noexcept;
 	float calculateDuration(const std::array<const Crew *, SLOT_COUNT> &complement, bool debug = false) noexcept;
-	
+
 	// old disused functions
 	void refine() noexcept;
 	unsigned int computeScore(const Crew& crew, std::uint8_t skill, size_t trait) const noexcept;
@@ -162,6 +162,7 @@ private:
 	float bestscore{0.0};
 
 	Timer totalTime{"voyage calculation"};
+	Timer totalTimeSA{"voyage calculation (simulated annealing)", false};
 	Timer voyageCalcTime{"actual calc", false};
 	Timer scoreUpdateTime{"score update", false};
 };

--- a/native/VoyageCalculator.h
+++ b/native/VoyageCalculator.h
@@ -114,6 +114,7 @@ public:
 
 private:
 	void calculate() noexcept;
+	void calculateSA() noexcept;
 	void findBest() noexcept;
 	void fillSlot(size_t slot, unsigned int minScore, size_t minDepth, size_t seedSlot, size_t thread = -1) noexcept;
 	void updateSlotRosterScores() noexcept;

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "xlsx-populate": "latest"
   },
   "dependencies": {
+    "bindings": "^1.3.0",
     "buffer": "5.0.8",
     "dexie": "latest",
     "fb": "latest",


### PR DESCRIPTION
I finally got enough time to dig into this and am happy with the result. After a few stumblings with the tools and "debugging", I have an updated algorithm for voyage time estimation.
It uses the crew data structures provided and the same UI update callback mechanism, the only thing replaced is the actual "calculate" method in the native/C++ code.
Instead of brute forcing the calculation with expensive parallelism, the simulated annealing approach uses random selections with a narrowing window and in my testing comes up with (slightly) better results in significantly less time. On my machine it is consistently 20-24ms vs the current algorithm at search depth 6 (default) is 200-230ms, at 7 is 1000-1060ms and at 5 is 42-50ms.
I'd appreciate any feedback and for you and Chewable to take a look before accepting the change.