### PR TITLE
Change ship sort by level to make more sense

### DIFF
--- a/src/components/ShipList.js
+++ b/src/components/ShipList.js
@@ -12,7 +12,10 @@ export class ShipList extends React.Component {
 		super(props);
 
 		this.state = {
-			items: sortItems(STTApi.ships, 'name'),
+			items: sortItems(STTApi.ships, 'name').map(ship => {
+				ship.sort_level = ship.max_level / ship.level;
+				return ship;
+			}),
 			schematics: STTApi.shipSchematics,
 			playerSchematics: STTApi.playerData.character.items.filter(item => item.type === 8),			
 			columns: [
@@ -49,9 +52,9 @@ export class ShipList extends React.Component {
 					fieldName: 'name'
 				},
 				{
-					key: 'max_level',
+					key: 'level',
 					name: 'Level',
-					fieldName: 'max_level',
+					fieldName: 'sort_level',
 					minWidth: 90,
 					maxWidth: 130,
 					isResizable: true,


### PR DESCRIPTION
I've updated the sort-by-level on the Ships page to sort by ship level "progress" rather than ship maximum level. This way, the ships that sort to the top when descending are those you have at max level and the ones at level zero are at the bottom.
It could be further improved to account for number of schematics in the inventory as well, but would add some complexity and would re-use the same logic applied to the first column, requiring some refactoring.
Sorting by the Rarity column is essentially the same as how this column sort was behaving, which mixed ships regardless of zero level and max level.