### PR TITLE
Compute remaining voyage time

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,6 +67,11 @@
         "condition_variable": "cpp",
         "ratio": "cpp",
         "set": "cpp",
-        "thread": "cpp"
+        "thread": "cpp",
+        "*.tcc": "cpp",
+        "cctype": "cpp",
+        "cwctype": "cpp",
+        "optional": "cpp",
+        "string_view": "cpp"
     }
 }

--- a/README.md
+++ b/README.md
@@ -100,13 +100,14 @@ You can inspect the active state of crew by clicking on the little "baloon" icon
 ### To get started:
 Clone the repo and build with `node.js` v 10.
 
-Minimal set of steps required (on a Windows machine)
+Minimal set of steps required
 * `git clone --recurse-submodules https://github.com/IAmPicard/StarTrekTimelinesSpreadsheet.git`
 * `cd StarTrekTimelinesSpreadsheet\STTApi`
 * `npm install`
 * `cd ..`
 * `npm install`
   * You may also need to `npm install electron` if you see the message `Error: Electron failed to install correctly, please delete node_modules/electron and try installing again`
+  * You may need to `npm install bindings nan` if you see errors using the voyage estimator tool
 * `node_modules\.bin\electron-rebuild.cmd`
   * `node_modules/.bin/electron-rebuild` on Ubuntu
 * `npm run dev`
@@ -115,6 +116,15 @@ Minimal set of steps required (on a Windows machine)
 
 ##### Development
 * Run `npm run dev` to start webpack-dev-server. Electron will launch automatically after compilation.
+
+If changes are made to the C++ native codebase under `/native`:
+* You can compile to see warnings/errors with the following (though it does not build for proper integration with the app)
+  * `$ rm -rf native/build/Release`
+  * `$ cd native/build`
+  * `$ make`
+To rebuild for use with the app run the `electron-rebuild` executable under `node_modules/.bin/`
+
+If you delete `node_modules/stt*` to get back to a cleaner state, `npm install` again to rebuild the C++ modules. If the install fails, revert any local changes to `package-lock.json`.
 
 ##### Production
 _You have two options, an automatic build or two manual steps_

--- a/native/NativeExtension.cpp
+++ b/native/NativeExtension.cpp
@@ -179,6 +179,9 @@ class VoyageCrewRankWorker : public Nan::AsyncProgressWorker
 	std::unique_ptr<VoyageTools::VoyageCalculator> voyageCalculator;
 };
 
+constexpr std::array<const char *, VoyageTools::SKILL_COUNT> VoyageCrewRankWorker::skillNames;
+constexpr std::array<const char *, VoyageTools::SKILL_COUNT> VoyageCrewRankWorker::altSkillNames;
+
 NAN_METHOD(calculateVoyageRecommendations)
 {
 	if (info.Length() != 3)

--- a/native/VoyageCalculator.cpp
+++ b/native/VoyageCalculator.cpp
@@ -530,7 +530,7 @@ float VoyageCalculator::calculateDuration(const std::array<const Crew *, SLOT_CO
 
 	//unsigned int PrimarySkill = totals.skills[binaryConfig.primarySkill];
 	//unsigned int SecondarySkill = totals.skills[binaryConfig.secondarySkill];
-	unsigned int MaxSkill = 0;
+	float MaxSkill = 0;
 
 	std::array<float, SKILL_COUNT> hazSkillVariance;
 	for (size_t iSkill = 0; iSkill < SKILL_COUNT; ++iSkill)
@@ -550,10 +550,13 @@ float VoyageCalculator::calculateDuration(const std::array<const Crew *, SLOT_CO
 		log << "primary skill prof variance: " << hazSkillVariance[binaryConfig.primarySkill] << std::endl;
 	}
 
-	unsigned int elapsedHours = 0; // TODO: deal with this later
-	unsigned int elapsedHazSkill = elapsedHours * hazSkillPerHour;
+	float elapsedHours = 0; // TODO: deal with this later
+	float elapsedHazSkill = elapsedHours * hazSkillPerHour;
+	unsigned int elapsedShipAM = binaryConfig.remainingAntiMatter;
+	if (elapsedShipAM <= 0)
+		elapsedShipAM = shipAM;
 
-	MaxSkill = std::max((unsigned int)0, MaxSkill - elapsedHazSkill);
+	MaxSkill = std::max(0.0f, MaxSkill - elapsedHazSkill);
 	float endVoySkill = MaxSkill * (1 + hazSkillVariance[binaryConfig.primarySkill]);
 
 	const std::array<unsigned int, SKILL_COUNT> &skills = totals.skills;
@@ -599,8 +602,8 @@ float VoyageCalculator::calculateDuration(const std::array<const Crew *, SLOT_CO
 		float am = (float)(shipAM + shipAM * binaryConfig.extendsTarget);
 		for (size_t iSkill = 0; iSkill < SKILL_COUNT; iSkill++)
 		{
-			unsigned int skill = skills[iSkill];
-			skill = std::max((unsigned int)0, skill - elapsedHazSkill);
+			float skill = skills[iSkill];
+			skill = std::max(0.0f, skill - elapsedHazSkill);
 			float chance = skillChances[iSkill];
 
 			// skill amount for 100% pass

--- a/native/VoyageCalculator.cpp
+++ b/native/VoyageCalculator.cpp
@@ -124,7 +124,7 @@ VoyageCalculator::VoyageCalculator(const char* jsonInput, bool rankMode) noexcep
 
 			// compute score - not really used anymore except for checking whether
 			//	crew can fit in slot (score > 0), and perhaps for troubleshooting
-			slotRoster[iCrew].score = 
+			slotRoster[iCrew].score =
 				computeScore(slotRoster[iCrew], binaryConfig.slotSkills[iSlot], iSlot);
 
 			// set references
@@ -173,7 +173,7 @@ void VoyageCalculator::calculate() noexcept
 {
 	for (unsigned int iteration = 1;;++iteration) {
 		log << "iteration " << iteration << std::endl;
-		
+
 		float prevBest = bestscore;
 
 		resetRosters();
@@ -288,7 +288,7 @@ void VoyageCalculator::findBest() noexcept
 	log << "minScore: " << minScore << std::endl;
 	log << "primary: " << SkillName(binaryConfig.primarySkill) << std::endl;
 	log << "secondary: " << SkillName(binaryConfig.secondarySkill) << std::endl;
-	
+
 	{ Timer::Scope timer(voyageCalcTime);
 		for (size_t iMinDepth = minDepth; iMinDepth < MAX_SCAN_DEPTH; ++iMinDepth)
 		{
@@ -331,7 +331,7 @@ void VoyageCalculator::fillSlot(size_t iSlot, unsigned int minScore, size_t minD
 
 		if (slot == seedSlot) {
 			thread = iCrew;
-		} else 
+		} else
 		if (crew.original->considered[thread])
 			continue;
 
@@ -387,7 +387,7 @@ void VoyageCalculator::refine() noexcept
 	for (const Crew &crew : roster) {
 		std::fill(crew.considered.begin(), crew.considered.end(), false);
 	}
-	
+
 	auto considered = bestconsidered;
 	for (size_t iSlot = 0; iSlot < SLOT_COUNT; ++iSlot) {
 		considered[iSlot]->original->considered[0] = true;
@@ -396,7 +396,7 @@ void VoyageCalculator::refine() noexcept
 	// refinement loops
 	for (;;) {
 		bool refinementFound = false;
-		
+
 		auto fUpdateBest = [&,this]{
 			refinementFound = true;
 			float score = calculateDuration(considered);
@@ -422,7 +422,7 @@ void VoyageCalculator::refine() noexcept
 					continue;
 				/*if (crew.score < considered[iSlot]->score/2)
 					break;*/
-				
+
 				// try swapping
 				const Crew *prevCrew = considered[iSlot];
 				considered[iSlot] = crew;
@@ -492,7 +492,7 @@ float VoyageCalculator::calculateDuration(const std::array<const Crew *, SLOT_CO
 			totals.skills[iSkill] += crew->skills[iSkill];
 			// apparently it's possible for min to be higher than max:
 			// https://forum.disruptorbeam.com/stt/discussion/4078/guinan-is-so-awesome-her-min-prof-roll-is-higher-than-her-max-prof-roll
-			totalProfRange[iSkill] += 
+			totalProfRange[iSkill] +=
 				std::max(crew->skillMaxProfs[iSkill], crew->skillMinProfs[iSkill]) -
 				crew->skillMinProfs[iSkill];
 		}

--- a/native/VoyageCalculator.cpp
+++ b/native/VoyageCalculator.cpp
@@ -83,6 +83,19 @@ VoyageCalculator::VoyageCalculator(const char* jsonInput, bool rankMode) noexcep
 
 	std::vector<uint8_t> temp = j["binaryConfig"];
 	memcpy(&binaryConfig, temp.data(), temp.size());
+	auto tempEstPos = j.find("estimateBinaryConfig");
+	if (tempEstPos != j.end())
+	{
+		std::vector<uint8_t> tempEst = *tempEstPos;
+		memcpy(&estimateBinaryConfig, tempEst.data(), tempEst.size());
+	}
+	else
+	{
+		estimateBinaryConfig.elapsedTimeHours = 0;
+		estimateBinaryConfig.elapsedTimeMinutes = 0;
+		estimateBinaryConfig.remainingAntiMatter = 0;
+		std::fill(estimateBinaryConfig.slotCrewIds, estimateBinaryConfig.slotCrewIds + SLOT_COUNT, 0);
+	}
 
 	for (const auto &crew : j["crew"])
 	{

--- a/native/VoyageCalculator.h
+++ b/native/VoyageCalculator.h
@@ -118,7 +118,7 @@ private:
 	void updateSlotRosterScores() noexcept;
 	void resetRosters() noexcept;
 	float calculateDuration(const std::array<const Crew *, SLOT_COUNT> &complement, bool debug = false) noexcept;
-	
+
 	// old disused functions
 	void refine() noexcept;
 	unsigned int computeScore(const Crew& crew, std::uint8_t skill, size_t trait) const noexcept;
@@ -152,7 +152,18 @@ private:
 	};
 	#pragma pack(pop)
 
+	#pragma pack(push, 1)
+	struct EstimateBinaryConfig
+	{
+		std::uint8_t elapsedTimeHours;
+		std::uint8_t elapsedTimeMinutes;
+		std::uint16_t remainingAntiMatter;
+		std::uint32_t slotCrewIds[SLOT_COUNT];
+	};
+	#pragma pack(pop)
+
 	BinaryConfig binaryConfig;
+	EstimateBinaryConfig estimateBinaryConfig;
 
 	std::array<std::vector<const Crew*>, SLOT_COUNT> sortedSlotRosters;
 

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "xlsx-populate": "latest"
   },
   "dependencies": {
+    "bindings": "^1.3.0",
     "buffer": "5.0.8",
     "dexie": "latest",
     "fb": "latest",

--- a/src/components/VoyageTools.js
+++ b/src/components/VoyageTools.js
@@ -107,7 +107,7 @@ export class VoyageCrew extends React.Component {
 				<div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap' }}>
 					{crewSpans}
 				</div>
-				<h3>Estimated duration: <b>{this.state.estimatedDuration.toFixed(2)} hours</b></h3>
+				<h3>Estimated duration: <b>{formatTimeSeconds(this.state.estimatedDuration * 60 * 60)}</b></h3>
 				<br />
 			</div>);
 		} else {

--- a/src/components/VoyageTools.js
+++ b/src/components/VoyageTools.js
@@ -545,8 +545,11 @@ export class VoyageLog extends React.Component {
 	}
 
 	async _betterEstimate() {
-		// TODO(Paul): check if these values are actually needed for the estimate calculation
+		const assignedCrew = this.state.voyage.crew_slots.map(slot => slot.crew.id);
+		const assignedRoster = STTApi.roster.filter(crew => assignedCrew.includes(crew.crew_id));
+
 		let options = {
+			// first three not needed for estimate calculation
 			searchDepth: 0,
 			extendsTarget: 0,
 			shipAM: 0,
@@ -555,12 +558,11 @@ export class VoyageLog extends React.Component {
     		skillMatchingMultiplier: 1.1,
 			traitScoreBoost: 200,
 			voyage_description: STTApi.playerData.character.voyage_descriptions[0],
-			// TODO: the roster could probably be trimmmed down to just the currently on voyage 12 crew, to save on serialization
-			roster: STTApi.roster,
-			// Estimate-specific values
+			roster: assignedRoster,
+			// Estimate-specific parameters
 			voyage_duration: this.state.voyage.voyage_duration,
 			remainingAntiMatter: this.state.voyage.hp,
-			assignedCrew: this.state.voyage.crew_slots.map(slot => slot.crew.id)
+			assignedCrew
 		};
 
 		estimateVoyageRemaining(options, (estimate) => this.setState({ estimatedMinutesLeft: estimate }))


### PR DESCRIPTION
I've updated the native code (and JS to send parameters) to compute the estimated voyage time remaining. Instead of searching for crew and testing, it uses the current voyage crew, current antimatter, and subtracts the elapsed time from the total estimated voyage time to get an answer.
I could use your help in how you would like to integrate the logic. In my branch, I have overridden the "calculate" button on the voyage tab to estimate voyage time remaining if there is a voyage currently running, but the UI should have some differences. Let me know if you have suggestions or would like to tackle the UI integration yourself.