### PR TITLE
Updates to Needed Equipment accounting

### DIFF
--- a/src/components/NeededEquipment.js
+++ b/src/components/NeededEquipment.js
@@ -127,6 +127,18 @@ export class NeededEquipment extends React.Component {
 							});
 						});
 					}
+					else {
+						//NOTE: this clause can be removed to avoid zero counts for crew members
+						// Track the crew that needs them, but retain zero count (since the item is partially built)
+						// in case the intermediate item gets consumed elsewhere
+						equipment.recipe.demands.forEach((recipeItem) => {
+							unparsedEquipment.push({
+								archetype: recipeItem.archetype_id,
+								need: 0,
+								crew: eq.crew
+							});
+						});
+					}
 
 				}
 			} else if (equipment.item_sources && (equipment.item_sources.length > 0) || cadetableItems.has(equipment.id)) {
@@ -313,6 +325,7 @@ export class NeededEquipment extends React.Component {
 		if (this.state.neededEquipment) {
 			return (<div className='tab-panel' data-is-scrollable='true'>
 				<p>Equipment required to fill all open slots for all crew currently in your roster, for their current level band</p>
+				<small>Note that partially complete recipes result in zero counts for some crew and items</small>
 
 				{this.state.neededEquipment.map((entry, idx) =>
 					<div key={idx} className="ui raised segment" style={{ display: 'grid', gridTemplateColumns: '128px auto', gridTemplateAreas: `'icon name' 'icon details'`, padding: '8px 4px', margin: '8px' }}>


### PR DESCRIPTION
I've added tracking of which crew members need how many of equipment as you iterate through them, and also have applied a fix for #161
I added a clause in the fix that will add "needs zero" of equipment that is partially built, so the end of the list sorted by need count contains all the requirements to fully build those already partially built items.
I have accounted for a partially built item not being used multiple times, but this "needs zero" is there in case a partially built item gets used unexpectedly on a crew, which would result in someone else then showing up as needing it when they did not before. This is a consequence of iterating a single time; the first crew that encounters a need for a partially built item would "consume" it, and subsequent crew (in undefined order) would then show that they "need" the materials to build some. Since the crew order is undefined, I thought it better to show the consequence of the partially built item rather than entirely omitting it from the output. However, this can be changed by removing the clause from the last commit, 149f8f2