### PR TITLE
Add Needed Equipment search/filter box and implement basic filter logic

### DIFF
--- a/src/components/NeededEquipment.js
+++ b/src/components/NeededEquipment.js
@@ -119,7 +119,11 @@ export class NeededEquipment extends React.Component {
 					// if total requirements exceed inventory
 					if (found.needed > 0) {
 						// how many can be filled for this equipment demand
-						let partialNeeded = Math.min(eq.need, found.needed);
+						let partialNeeded = eq.need;
+						// If this new requirement pushed past inventory amount, only need a partial amount equal to the overlap
+						if (found.needed < eq.need) {
+							partialNeeded = eq.need - found.needed;
+						}
 						equipment.recipe.demands.forEach((recipeItem) => {
 							unparsedEquipment.push({
 								archetype: recipeItem.archetype_id,


### PR DESCRIPTION
I've added filter capability to the needed equipment page. The simple text search field filters equipment results by numeric (if parses to int) rarity, needed, have, and by string equipment name, crew name, or mission name.
Two minor improvements it could use: it is somewhat slow, so perhaps could benefit from some caching; second, it does not refresh when the toggle filters change, so may show unexpected results until it is cleared or typed in again.
Additional features could be to add custom criteria like "rarity:3" to limit a search for "3" to only rarity (excluding any have=3 or needed=3 hits), or perahps "have:<5" to go crazier and allow conditions in the search criteria. It may also be helpful to highlight the text in the page where the filter match hit was made.