### PR TITLE
Minor voyage and equip updates

### DIFF
--- a/src/components/NeededEquipment.js
+++ b/src/components/NeededEquipment.js
@@ -573,7 +573,8 @@ export class NeededEquipment extends React.Component {
 							<button style={{ marginBottom: '8px' }} className="ui button" onClick={() => this._replicateDialog.current.show(entry.equipment)}>Replicate...</button>
 						</div>
 						<div style={{ gridArea: 'name', alignSelf: 'start', margin: '0' }}>
-							<h4>{`${entry.equipment.name} (need ${entry.needed}, have ${entry.have})`}</h4>
+							<h4><a href={'https://stt.wiki/wiki/' + entry.equipment.name.split(' ').join('_')} target='_blank'>{entry.equipment.name}</a>
+							{` (need ${entry.needed}, have ${entry.have})`}</h4>
 						</div>
 						<div style={{ gridArea: 'details', alignSelf: 'start' }}>
 							{this.renderSources(entry.equipment, entry.counts)}

--- a/src/components/VoyageTools.js
+++ b/src/components/VoyageTools.js
@@ -447,14 +447,16 @@ export class VoyageLog extends React.Component {
 						// For crew, check if it's useful or not
 						let have = STTApi.roster.filter(crew => crew.symbol === item.symbol);
 						if (have.length > 0) {
-							if (!have.some(c => c.max_rarity === c.rarity)) {
-								return <span style={{ fontWeight: 'bold' }}>NEW STAR FOR CREW!</span>;
-							} else {
-								return <span>Duplicate of immortalized crew (airlock-able)</span>;
+							if (have.some(c => c.frozen === 1)) {
+								return <span>Duplicate of frozen crew (airlock-able)</span>;
 							}
-						} else {
-							return <span style={{ fontWeight: 'bold' }}>NEW CREW!</span>;
+							if (have.some(c => c.max_rarity === c.rarity)) {
+								return <span>Duplicate of fully-fused crew (airlock-able)</span>;
+							}
+
+							return <span style={{ fontWeight: 'bold' }}>NEW STAR FOR CREW!</span>;
 						}
+						return <span style={{ fontWeight: 'bold' }}>NEW CREW!</span>;
 					}
 
 					let typeName = CONFIG.REWARDS_ITEM_TYPE[item.item_type];

--- a/src/components/VoyageTools.js
+++ b/src/components/VoyageTools.js
@@ -562,7 +562,10 @@ export class VoyageLog extends React.Component {
 				voyageRewards: voyageRewards
 			});
 
-			this._betterEstimate();
+			// Avoid estimating if voyage is not ongoing
+			if (voyage.state !== "recalled" && voyage.state !== "failed") {
+				this._betterEstimate();
+			}
 		}
 	}
 


### PR DESCRIPTION
I've added a link to the wiki on the Needed Equipment page - I found it helpful to be able to jump to the wiki to see their estimation for drop rates before picking a mission
I also updated the voyage page to remove the native call to estimate voyage time if no voyage is active and update the display text for crew members. Since it is a pain to actually compute "immortalized" and that detail seems to not be provided by the API, I've instead used the terms "frozen" and "fully fused" and distinguished them. I found that a 1* crew at level 1 in my crew roster was flagged as "Duplicate of immortalized crew" incorrectly.